### PR TITLE
Add functionality to access key and signature lengths over ffi interface

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -134,7 +134,7 @@ pub extern "C" fn generate_key(out_key: &mut [u8;constants::PRIVATE_KEY_LENGTH])
 }
 
 #[no_mangle]
-pub extern "C" fn validate_public_key(public_key: &[u8;32]) -> c_int{
+pub extern "C" fn validate_public_key(public_key: &[u8;constants::PUBLIC_KEY_LENGTH]) -> c_int{
     match keys::validate_public(&public_key){
         Err(err) => {
             let error_code = errors::get_error_code(&err);
@@ -146,7 +146,7 @@ pub extern "C" fn validate_public_key(public_key: &[u8;32]) -> c_int{
 }
 
 #[no_mangle]
-pub extern "C" fn validate_private_key(private_key: &[u8;32]) -> c_int{
+pub extern "C" fn validate_private_key(private_key: &[u8;constants::PRIVATE_KEY_LENGTH]) -> c_int{
     match keys::validate_private(&private_key){
         Err(err) => {
             let error_code = errors::get_error_code(&err);
@@ -157,3 +157,20 @@ pub extern "C" fn validate_private_key(private_key: &[u8;32]) -> c_int{
     };
 }
 
+///Returns private key length in bytes
+#[no_mangle]
+pub extern "C" fn get_private_key_length() -> c_int{
+    constants::PRIVATE_KEY_LENGTH as i32
+}
+
+///Returns public key length in bytes
+#[no_mangle]
+pub extern "C" fn get_public_key_length() -> c_int{
+    constants::PUBLIC_KEY_LENGTH as i32
+}
+
+///Returns signature length in bytes
+#[no_mangle]
+pub extern "C" fn get_signature_length() -> c_int{
+    constants::SIGNATURE_LENGTH as i32
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -25,9 +25,9 @@ type Result<T> = result::Result<T, failure::Error>;
 
 pub fn get_signature_result_with_error() -> Result<bool> {
     let mut invalid_signature : [u8; constants::SIGNATURE_LENGTH] = [0; constants::SIGNATURE_LENGTH];
-    invalid_signature[63] = 32;
-    let mut private_key : [u8;32] = [0;32];
-    let mut public_key : [u8;32] = [0;32];
+    invalid_signature[constants::SIGNATURE_LENGTH - 1] = 32;
+    let mut private_key : [u8;constants::PRIVATE_KEY_LENGTH] = [0;constants::PRIVATE_KEY_LENGTH];
+    let mut public_key : [u8;constants::PUBLIC_KEY_LENGTH] = [0;constants::PUBLIC_KEY_LENGTH];
     keys::generate_key(&mut private_key);
     keys::publickey_from_private(&mut public_key, &mut private_key);
     let message = String::from("Message text");

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -24,7 +24,7 @@ use std::result;
 
 pub type Result<T> = result::Result<T, failure::Error>;
 
-pub fn publickey_from_private(out_publickey: &mut [u8;constants::PUBLIC_KEY_LENGTH],private_key: &[u8;constants::PRIVATE_KEY_LENGTH]) -> Result<()> {
+pub fn publickey_from_private(out_publickey: &mut [u8;constants::PUBLIC_KEY_LENGTH], private_key: &[u8;constants::PRIVATE_KEY_LENGTH]) -> Result<()> {
     let secret_key: SecretKey = SecretKey::from_bytes(private_key)?;
     let public_key: PublicKey = (&secret_key).into();
     out_publickey.copy_from_slice(&public_key.to_bytes());
@@ -38,12 +38,12 @@ pub fn generate_key(out_key: &mut [u8;constants::PRIVATE_KEY_LENGTH]) -> Result<
     Ok(())
 }
 
-pub fn validate_public(public_key: &[u8;32]) -> Result<()>{
+pub fn validate_public(public_key: &[u8;constants::PUBLIC_KEY_LENGTH]) -> Result<()>{
     PublicKey::from_bytes(public_key)?;
     Ok(())
 }
 
-pub fn validate_private(private_key: &[u8;32]) -> Result<()>{
+pub fn validate_private(private_key: &[u8; constants::PRIVATE_KEY_LENGTH]) -> Result<()>{
     SecretKey::from_bytes(private_key)?;
     Ok(())
 }

--- a/src/std_signature.rs
+++ b/src/std_signature.rs
@@ -54,10 +54,10 @@ mod tests {
 
     #[test]
     fn test_sign_verify(){
-        let initial_sig: [u8;64] = [0;64];
-        let mut out_sig: [u8;64] = Clone::clone(&initial_sig);
+        let initial_sig: [u8;constants::SIGNATURE_LENGTH] = [0;constants::SIGNATURE_LENGTH];
+        let mut out_sig: [u8;constants::SIGNATURE_LENGTH] = Clone::clone(&initial_sig);
 
-        let mut key: [u8;32] = [0;32];
+        let mut key: [u8;constants::PRIVATE_KEY_LENGTH] = [0;constants::PRIVATE_KEY_LENGTH];
         assert!(keys::generate_key(&mut key).is_ok());
         let message = String::from("You are a sacrifice article that I cut up rough now");
         assert!(sign(&mut out_sig, &key, message.as_ptr(), message.len()).is_ok());
@@ -70,10 +70,10 @@ mod tests {
 
     #[test]
     fn test_sign_verify_fails(){
-        let mut out_sig: [u8;64] = [0;64];
+        let mut out_sig: [u8;constants::SIGNATURE_LENGTH] = [0;constants::SIGNATURE_LENGTH];
         let message = String::from("You are a sacrifice article that I cut up rough now");
         let message2 = String::from("Mr. speaker, we are for the big");
-        let mut key: [u8;32] = [0;32];
+        let mut key: [u8;constants::PRIVATE_KEY_LENGTH] = [0;constants::PRIVATE_KEY_LENGTH];
         assert!(keys::generate_key(&mut key).is_ok());
 
         assert!(sign(&mut out_sig, &key, message.as_ptr(), message.len()).is_ok());


### PR DESCRIPTION
Add ffi functions to get public key, private key and signature lengths in bytes. 
Replace hardcoded values with constants where missed previously.

Closes #16 