### PR TITLE
Add context to signing

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -26,6 +26,10 @@ pub const PRIVATE_KEY_LENGTH: usize = 32;
 /// The length of an ed25519 `PublicKey`, in bytes.
 pub const PUBLIC_KEY_LENGTH: usize = 32;
 
+pub const CONTEXT_MAX_LENGTH: usize = 255;
+
 pub const SIGNATURE_ERROR : i32 = 101;
+
+pub const CONTEXT_LENGTH_ERROR: i32 = 201;
 
 pub const UNKNOWN_ERROR : i32 = -1;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,7 @@ pub fn take_last_error() -> Option<Box<failure::Error>> {
 
 /// Retrieve error code corresponding to error type.
 pub fn get_error_code(err : &failure::Error ) -> i32 {
+    println!("{}", err.as_fail());
     if let Some(_) = err.downcast_ref::<ed25519_dalek::SignatureError>() {
         return constants::SIGNATURE_ERROR;
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -78,83 +78,55 @@ pub unsafe extern "C" fn last_error_message(buffer: *mut c_char, length: c_int) 
     error_message.len() as c_int
 }
 
-/// Verifies that an ed25519 signature corresponds to the provided public key and message. Returns 0 if no error encountered, otherwise returns an error code. Sets value of is_verified based of verification outcome.
+/// Verifies that an ed25519 signature corresponds to the provided public key, message, and context. Returns 0 if no error encountered, otherwise returns an error code. Sets value of is_verified based of verification outcome.
 #[no_mangle]
-pub extern "C" fn std_verify(signature: & [u8;constants::SIGNATURE_LENGTH], publickey: &[u8;constants::PUBLIC_KEY_LENGTH], message: *const u8, message_length: usize , is_verified: &mut [u8;1]) -> c_int {
-    match std_signature::verify(signature, publickey, message, message_length){
-        Err(err) => {
-            let error_code = errors::get_error_code(&err);
-            errors::update_last_error(err);
-            return error_code;
-        }
-        Ok(b) => {
-            is_verified[0] = b as u8;
-            return 0;
-            }
-    };
+pub extern "C" fn std_verify(signature: & [u8;constants::SIGNATURE_LENGTH], 
+                             publickey: &[u8;constants::PUBLIC_KEY_LENGTH], 
+                             message: *const u8, 
+                             message_length: usize,
+                             context: *const u8, 
+                             context_length: usize,  
+                             is_verified: &mut [u8;1]) -> c_int {
+    let result = std_signature::verify_with_context(signature, publickey, message, message_length, context, context_length);
+    result.and_then(|b: bool| {is_verified[0] = b as u8; Ok(b)});
+    result.get_ffi_return_code()
 }
 
 /// Creates a signature from private key and message. Returns 0 if no error encountered, otherwise returns an error code.
 #[no_mangle]
-pub extern "C" fn std_sign(out_signature: &mut [u8;constants::SIGNATURE_LENGTH], private_key: &[u8;constants::PRIVATE_KEY_LENGTH], message: *const u8, message_length: usize) -> c_int {
-   let _res = match std_signature::sign(out_signature, private_key, message, message_length){
-        Err(err) => {
-            let error_code = errors::get_error_code(&err);
-            errors::update_last_error(err);
-            return error_code;
-        }
-        Ok(()) => {return 0;}
-    };
+pub extern "C" fn std_sign(out_signature: &mut [u8;constants::SIGNATURE_LENGTH], 
+                           private_key: &[u8;constants::PRIVATE_KEY_LENGTH], 
+                           message: *const u8, 
+                           message_length: usize,
+                           context: *const u8, 
+                           context_length: usize) -> c_int {
+    let result = std_signature::sign_with_context(out_signature, private_key, message, message_length, context, context_length);
+    result.get_ffi_return_code()
 }
 
 /// Returns correponding public key, given a private key. Returns 0 if sucessful, otherwise returns an error code.
 #[no_mangle]
 pub extern "C" fn publickey_from_private(out_publickey: &mut [u8;constants::PUBLIC_KEY_LENGTH],private_key: &[u8;constants::PRIVATE_KEY_LENGTH]) -> c_int {
-    let _res = match keys::publickey_from_private(out_publickey, private_key){
-        Err(err) => {
-            let error_code = errors::get_error_code(&err);
-            errors::update_last_error(err);
-            return error_code;
-        }
-        Ok(()) => {return 0;}
-    };
+    let result = keys::publickey_from_private(out_publickey, private_key);
+    result.get_ffi_return_code()
 }
 
 /// Randomly generated private key. Returns 0 if sucessful, otherwise returns an error code.
 #[no_mangle]
 pub extern "C" fn generate_key(out_key: &mut [u8;constants::PRIVATE_KEY_LENGTH]) -> c_int {
-    let _res = match keys::generate_key(out_key){
-        Err(err) => {
-            let error_code = errors::get_error_code(&err);
-            errors::update_last_error(err);
-            return error_code;
-        }
-        Ok(()) => {return 0;}
-    };
+    let result = keys::generate_key(out_key);
+    result.get_ffi_return_code()
 }
 
 #[no_mangle]
 pub extern "C" fn validate_public_key(public_key: &[u8;constants::PUBLIC_KEY_LENGTH]) -> c_int{
-    match keys::validate_public(&public_key){
-        Err(err) => {
-            let error_code = errors::get_error_code(&err);
-            errors::update_last_error(err);
-            return error_code;
-            }
-        Ok(()) => {return 0;}
-    };
+    let result = keys::validate_public(&public_key);
+    result.get_ffi_return_code()
 }
 
 #[no_mangle]
 pub extern "C" fn validate_private_key(private_key: &[u8;constants::PRIVATE_KEY_LENGTH]) -> c_int{
-    match keys::validate_private(&private_key){
-        Err(err) => {
-            let error_code = errors::get_error_code(&err);
-            errors::update_last_error(err);
-            return error_code;
-            }
-        Ok(()) => {return 0;}
-    };
+    keys::validate_private(&private_key).get_ffi_return_code()
 }
 
 ///Returns private key length in bytes
@@ -173,4 +145,41 @@ pub extern "C" fn get_public_key_length() -> c_int{
 #[no_mangle]
 pub extern "C" fn get_signature_length() -> c_int{
     constants::SIGNATURE_LENGTH as i32
+}
+
+pub trait ResultEx<T>{
+    fn get_ffi_return_code(self) -> c_int;
+}
+
+impl<T> ResultEx<T> for Result<T,failure::Error> {
+    fn get_ffi_return_code(self) -> c_int{
+        match self{
+            Err(err) => {
+                let error_code = errors::get_error_code(&err);
+                errors::update_last_error(err);
+                return error_code;
+            }
+            Ok(_t) => {
+                return 0
+            }
+        };    
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_sign_verify_with_context(){
+        let initial_sig: [u8;constants::SIGNATURE_LENGTH] = [0;constants::SIGNATURE_LENGTH];
+        let mut out_sig: [u8;constants::SIGNATURE_LENGTH] = Clone::clone(&initial_sig);
+
+        let mut key: [u8;constants::PRIVATE_KEY_LENGTH] = [0;constants::PRIVATE_KEY_LENGTH];
+        assert!(keys::generate_key(&mut key).is_ok());
+        let message = String::from("You are a sacrifice article that I cut up rough now");
+        let context = String::from("This is a free online calculator which counts the number of characters or letters in a text, useful for your tweets on Twitter, as well as a multitude of other applications. Whether it is Snapchat, Twitter, Facebook, Yelp or just a note to co-workers or business officials, the number of actual characters matters. ");
+        assert_eq!(std_sign(&mut out_sig, &key, message.as_ptr(), message.len(), context.as_ptr(), context.len()), 2);
+
+        
+    }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -31,5 +31,6 @@ pub fn get_signature_result_with_error() -> Result<bool> {
     keys::generate_key(&mut private_key);
     keys::publickey_from_private(&mut public_key, &mut private_key);
     let message = String::from("Message text");
-    std_signature::verify(&invalid_signature, &public_key, message.as_ptr(), message.len())
+    let context = String::from("Context text");
+    std_signature::verify(&invalid_signature, &public_key, message.as_ptr(), message.len(), context.as_ptr(), context.len())
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -53,7 +53,7 @@ mod tests {
     use super::*;
     
     #[test]
-    fn test_generate_key(){
+    fn can_generate_private_key(){
         let initial_key: [u8;constants::PRIVATE_KEY_LENGTH] = [0;constants::PRIVATE_KEY_LENGTH];
         let mut out_key: [u8;constants::PRIVATE_KEY_LENGTH] = Clone::clone(&initial_key);
         assert_eq!(out_key,initial_key, "arrays should be the same");
@@ -62,7 +62,7 @@ mod tests {
     }
 
     #[test]
-    fn test_publickey_from_private(){
+    fn can_get_public_key_from_private_key(){
         let mut privatekey: [u8;constants::PRIVATE_KEY_LENGTH] = [0;constants::PRIVATE_KEY_LENGTH];
         assert!(generate_key(&mut privatekey).is_ok());
         let mut out_publickey: [u8;constants::PUBLIC_KEY_LENGTH] = [0;constants::PUBLIC_KEY_LENGTH];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 extern crate ed25519_dalek;
 extern crate rand;
 extern crate libc;
-extern crate failure;
+#[macro_use] extern crate failure;
 #[macro_use] extern crate log;
 
 mod ffi;

--- a/src/std_signature.rs
+++ b/src/std_signature.rs
@@ -22,6 +22,7 @@ use std::slice;
 use std::result;
 use crate::constants;
 use crate::keys;
+use failure;
 
 type Result<T> = result::Result<T, failure::Error>;
 
@@ -48,6 +49,63 @@ pub fn sign(out_signature: &mut [u8;constants::SIGNATURE_LENGTH], private_key: &
     Ok(())
 }
 
+pub fn sign_with_context(out_signature: &mut [u8;constants::SIGNATURE_LENGTH], 
+                         private_key: &[u8;constants::PRIVATE_KEY_LENGTH], 
+                         message: *const u8, 
+                         message_length: usize, 
+                         context: *const u8, 
+                         context_length: usize) 
+                         -> Result<()>{
+   let message_array = unsafe {
+        assert!(!message.is_null());
+        slice::from_raw_parts(message, message_length)
+    };
+
+    let context_array = unsafe {
+        assert!(!context.is_null());
+        slice::from_raw_parts(context, context_length)
+    };
+
+    if context_array.len() > 255 {
+        bail!("Ahh")
+    }
+
+    let secret_key: SecretKey = SecretKey::from_bytes(private_key)?;
+    let public_key: PublicKey = (&secret_key).into();
+    let keypair: Keypair  = Keypair{ secret: secret_key, public: public_key };
+    let mut prehashed: Sha512 = Sha512::new();
+    prehashed.input(message_array);
+    let signature: Signature = keypair.sign_prehashed(prehashed, Some(context_array));
+    out_signature.copy_from_slice(&signature.to_bytes());
+    Ok(())
+}
+
+pub fn verify_with_context(signature: & [u8;constants::SIGNATURE_LENGTH], 
+                           publickey: &[u8;constants::PUBLIC_KEY_LENGTH], 
+                           message: *const u8, 
+                           message_length: usize,
+                           context: *const u8, 
+                           context_length: usize) 
+                           -> Result<bool>{
+   let message_array = unsafe {
+        assert!(!message.is_null());
+        slice::from_raw_parts(message, message_length)
+    };
+
+    let context_array = unsafe {
+        assert!(!context.is_null());
+        slice::from_raw_parts(context, context_length)
+    };
+
+
+
+    let public_key: PublicKey = PublicKey::from_bytes(publickey)?;
+    let signature: Signature = Signature::from_bytes(signature)?;
+    let mut prehashed: Sha512 = Sha512::new();
+    prehashed.input(message_array);
+    Ok(public_key.verify_prehashed(prehashed, Some(context_array), &signature).is_ok())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,8 +122,23 @@ mod tests {
 
         let secret_key: SecretKey = SecretKey::from_bytes(&key).expect("failed to create private key");
         let public_key: PublicKey = (&secret_key).into();
-        assert!(verify(&out_sig, &PublicKey::to_bytes(&public_key),message.as_ptr(), message.len()).is_ok());
-        assert_eq!(verify(&out_sig, &PublicKey::to_bytes(&public_key),message.as_ptr(), message.len()).unwrap(),true);
+        assert_eq!(verify(&out_sig, &PublicKey::to_bytes(&public_key),message.as_ptr(), message.len()).unwrap(), true);
+    }
+
+    #[test]
+    fn test_sign_verify_with_context(){
+        let initial_sig: [u8;constants::SIGNATURE_LENGTH] = [0;constants::SIGNATURE_LENGTH];
+        let mut out_sig: [u8;constants::SIGNATURE_LENGTH] = Clone::clone(&initial_sig);
+
+        let mut key: [u8;constants::PRIVATE_KEY_LENGTH] = [0;constants::PRIVATE_KEY_LENGTH];
+        assert!(keys::generate_key(&mut key).is_ok());
+        let message = String::from("You are a sacrifice article that I cut up rough now");
+        let context = String::from("TThis is a free online calculator which counts the number of characters or letters in a text, useful for your tweets on Twitter, as well as a multitude of other applications. Whether it is Snapchat, Twitter, Facebook, Yelp or just a note to co-workers or business officials, the number of actual characters matters. ");
+        assert!(sign_with_context(&mut out_sig, &key, message.as_ptr(), message.len(), context.as_ptr(), context.len()).is_ok());
+
+        let secret_key: SecretKey = SecretKey::from_bytes(&key).expect("failed to create private key");
+        let public_key: PublicKey = (&secret_key).into();
+        assert_eq!(verify_with_context(&out_sig, &PublicKey::to_bytes(&public_key),message.as_ptr(), message.len(), context.as_ptr(), context.len()).unwrap(), true);
     }
 
     #[test]


### PR DESCRIPTION
Now using ed25519ph instead of ed25519 for signing which allows adding a context to signature for domain separation.
Error handling refactored for reduced code duplication and custom errors
Closes #15 

Note: ed25519 test vector will no longer work and will need to be changed