### PR TITLE
Adding Community docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## [](https://github.com/catalyst-network/Community/Contributor-Code-of-Conduct#our-standards)Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+-   Using welcoming and inclusive language
+-   Being respectful of differing viewpoints and experiences
+-   Gracefully accepting constructive criticism
+-   Focusing on what is best for the community
+-   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+-   The use of sexualized language or imagery and unwelcome sexual attention or advances
+-   Trolling, insulting/derogatory comments, and personal or political attacks
+-   Public or private harassment
+-   Publishing others' private information, such as a physical or electronic address, without explicit permission
+-   Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## [](https://github.com/catalyst-network/Community/Contributor-Code-of-Conduct/Contributor-Code-of-Conduct#our-responsibilities)Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## [](https://github.com/catalyst-network/Community/Contributor-Code-of-Conduct/wiki/Contributor-Code-of-Conduct#scope)Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## [](https://github.com/catalyst-network/Community/Contributor-Code-of-Conduct/Contributor-Code-of-Conduct#enforcement)Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project lead at [nshcore@protonmail.ch](mailto:nshcore@protonmail.ch), which goes to @nshCore, or to [richard@maintainer.io](mailto:richard@maintainer.io), which goes to @RichardLit. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## [](https://github.com/catalyst-network/Community/Contributor-Code-of-Conduct/Contributor-Code-of-Conduct#attribution)Attribution
+
+This Code of Conduct is adapted from the  [Contributor Covenant](http://contributor-covenant.org/), version 1.4, available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,37 @@
 # catalyst-ffi
-A rust library providing ffi for functionality from dalek-cryptography along with some custom functions for use in confidential transactions
 
-# To install and test
+[![Discord](https://img.shields.io/discord/629667101774446593?color=blueviolet&label=discord)](https://discord.gg/anTP7xm)
+
+> A Rust library providing ffi for functionality from dalek-cryptography along with some custom functions for use in confidential transactions
+
+## Install
 
 Install Rust via the Rustup tool:
 
 ```curl https://sh.rustup.rs -sSf | sh```
 
-If ```rustc --version``` fails, restart your console to ensure changes to ```PATH``` have taken effect. 
+If ```rustc --version``` fails, restart your console to ensure changes to ```PATH``` have taken effect.
 
-To build and run the tests
-```cargo test``` 
+## Usage
 
-For benchmarking
-```cargo bench``` 
+TODO. We don't have this section done yet. If you'd like to help us by opening a PR for it, please do so!
+
+## Testing
+
+To build and run the tests:
+```cargo test```
+
+For benchmarking:
+```cargo bench```
+
+## Contribute
+
+**Take a look at our organization-wide [Contributing Guide](https://github.com/catalyst-network/Community/blob/master/CONTRIBUTING.md).** You'll find most of your questions answered there.
+
+As far as code goes, we would be happy to accept PRs! If you want to work on something, it'd be good to talk beforehand to make sure nobody else is working on it. You can reach us [on Discord](https://discord.gg/anTP7xm), or in the [issues section](https://github.com/catalyst-network/Cryptography.FFI.Rust/issues).
+
+Please note that we have a [Code of Conduct](CODE_OF_CONDUCT.md), and that all activity in the [@catalyst-network](https://github.com/catalyst-network) organization falls under it. Read it when you get the chance, as being part of this community means that you agree to abide by it. Thanks.
+
+## License
+
+[MIT](LICENSE) © 2019 Catalyst Network


### PR DESCRIPTION
This adds the CoC, and fills out the README. I want to know about the Usage section, though - how does one use this library? 

As well, we should add keywords to the GitHub repository when merging this.