### PR TITLE
Get rid of warning on build caused by unused manifest key

### DIFF
--- a/packages/catalyst-common/Cargo.toml
+++ b/packages/catalyst-common/Cargo.toml
@@ -9,7 +9,6 @@ homepage = "https://github.com/catalyst-network/catalyst-rs/packages/catalyst-co
 readme = "README.md"
 license = "MIT"
 keywords = ["rust", "cryptography", "crypto", "catalyst", "dalek-cryptography"]
-maintenance = { status = "actively-developed" }
 
 [dependencies]
 ed25519-dalek = { version = "1.0.0-pre.3", features = ["nightly", "serde"] }

--- a/packages/catalyst-ffi/Cargo.toml
+++ b/packages/catalyst-ffi/Cargo.toml
@@ -9,7 +9,6 @@ homepage = "https://github.com/catalyst-network/catalyst-rs/packages/catalyst-ff
 readme = "README.md"
 license = "MIT"
 keywords = ["rust", "cryptography", "crypto", "catalyst", "dalek-cryptography"]
-maintenance = { status = "actively-developed" }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Closes #55 